### PR TITLE
Configure I2C Pins on startup

### DIFF
--- a/configs/whisper-speedwagon-flex-test.conf
+++ b/configs/whisper-speedwagon-flex-test.conf
@@ -159,7 +159,7 @@ include_firmware="enable"
 python3_pkgs="Adafruit-Blinka"
 ##
 chroot_COPY_SETUP_SDCARD="enable"
-chroot_before_hook=""
+chroot_before_hook="scripts/whisper_chroot.sh"
 chroot_after_hook=""
 chroot_script="beagleboard.org-bullseye.sh"
 chroot_post_uenv_txt=""

--- a/configs/whisper-speedwagon-flex-test.conf
+++ b/configs/whisper-speedwagon-flex-test.conf
@@ -97,8 +97,8 @@ deb_additional_pkgs="	\
 
 ##
 rfs_username="debian"
-rfs_fullname="Beagle User"
-rfs_password="temppwd"
+rfs_fullname="Whisper Developer"
+rfs_password="whisperai"
 rfs_hostname="BeagleBone"
 rfs_root_password="root"
 #rfs_default_desktop="xfce"

--- a/scripts/whisper_chroot.sh
+++ b/scripts/whisper_chroot.sh
@@ -4,28 +4,32 @@
 # This could be expanded to different BBB images in the future.
 
 enable_i2c1_on_startup () {
-  cat > ${tempdir}/usr/local/src/set_pins.sh <<-__EOF__
+  # Make the pin configuration script
+  cat > configure_pins.sh <<-__EOF__
 #!/bin/bash -e
 
 # Config the i2c1 PINs
 config-pin p9.24 i2c
 config-pin p9.26 i2c
 __EOF__
-  sudo chmod +x ${tempdir}/usr/local/src/set_pins.sh
-  cat > ${tempdir}/etc/systemd/system/set_pins.service <<-__EOF__
+  sudo chmod +x configure_pins.sh
+  sudo mv configure_pins.sh ${tempdir}/home/debian
+
+  # Use systemctl to configure pins on startup
+  cat > configure_pins.service <<-__EOF__
 [Unit]
 Description=Setup for BBB pins
 
 [Service]
 Type=simple
-ExecStart=/bin/bash /usr/local/src/set_pins.sh
+ExecStart=/bin/bash /home/debian/configure_pins.sh
 
 [Install]
 WantedBy=multi-user.target
 __EOF__
-
-  sudo chroot "${tempdir}" systemctl start set_pins.service
-  sudo chroot "${tempdir}" systemctl enable set_pins.service
+  sudo mv configure_pins.service ${tempdir}/etc/systemd/system
+  sudo chroot "${tempdir}" systemctl start configure_pins.service
+  sudo chroot "${tempdir}" systemctl enable configure_pins.service
 }
 
 enable_i2c1_on_startup

--- a/scripts/whisper_chroot.sh
+++ b/scripts/whisper_chroot.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+#
+# Do the extra whisper installation steps.
+# This could be expanded to different BBB images in the future.
+
+enable_i2c1_on_startup () {
+  cat > ${tempdir}/usr/local/src/set_pins.sh <<-__EOF__
+    #!/bin/bash -e
+
+    # Config the i2c1 PINs
+    config-pin p9.24 i2c
+    config-pin p9.26 i2c
+  __EOF__
+  sudo chmod +x ${tempdir}/usr/local/src/set_pins.sh
+  cat > ${tempdir}/etc/systemd/system/set_pins.service <<-__EOF__
+    [Unit]
+    Description=Setup for BBB pins
+
+    [Service]
+    Type=simple
+    ExecStart=/bin/bash /usr/local/src/set_pins.sh
+
+    [Install]
+    WantedBy=multi-user.target
+  __EOF__
+
+  sudo chroot "${tempdir}" systemctl start set_pins.service
+  sudo chroot "${tempdir}" systemctl enable set_pins.service
+}
+
+enable_i2c1_on_startup

--- a/scripts/whisper_chroot.sh
+++ b/scripts/whisper_chroot.sh
@@ -5,24 +5,24 @@
 
 enable_i2c1_on_startup () {
   cat > ${tempdir}/usr/local/src/set_pins.sh <<-__EOF__
-    #!/bin/bash -e
+#!/bin/bash -e
 
-    # Config the i2c1 PINs
-    config-pin p9.24 i2c
-    config-pin p9.26 i2c
-  __EOF__
+# Config the i2c1 PINs
+config-pin p9.24 i2c
+config-pin p9.26 i2c
+__EOF__
   sudo chmod +x ${tempdir}/usr/local/src/set_pins.sh
   cat > ${tempdir}/etc/systemd/system/set_pins.service <<-__EOF__
-    [Unit]
-    Description=Setup for BBB pins
+[Unit]
+Description=Setup for BBB pins
 
-    [Service]
-    Type=simple
-    ExecStart=/bin/bash /usr/local/src/set_pins.sh
+[Service]
+Type=simple
+ExecStart=/bin/bash /usr/local/src/set_pins.sh
 
-    [Install]
-    WantedBy=multi-user.target
-  __EOF__
+[Install]
+WantedBy=multi-user.target
+__EOF__
 
   sudo chroot "${tempdir}" systemctl start set_pins.service
   sudo chroot "${tempdir}" systemctl enable set_pins.service


### PR DESCRIPTION
The built image correctly sets the pin on startup:
```
debian@BeagleBone:~$ config-pin -q p9.24

Current mode for P9_24 is:     i2c

debian@BeagleBone:~$ config-pin -q p9.26

Current mode for P9_26 is:     i2c
```