### PR TITLE
add disable emmc option, disable both emmc and video

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,8 @@ jobs:
             cd deploy/${image_name}
             sudo ./setup_sdcard.sh --img-4gb ${target}-${image_name} \
               --dtb beaglebone --distro-bootloader --enable-cape-universal \
-              --enable-uboot-disable-pru --enable-bypass-bootup-scripts
+              --enable-uboot-disable-pru --enable-bypass-bootup-scripts \
+              --enable-uboot-disable-emmc --enable-uboot-disable-video
 
             # Compress
             sudo xz -T0 -z -3 -v -v --verbose ${target}-${image_name}-${size}.img

--- a/tools/setup_sdcard.sh
+++ b/tools/setup_sdcard.sh
@@ -1193,7 +1193,11 @@ populate_rootfs () {
 				echo "#dtb_overlay=<file8>.dtbo" >> ${wfile}
 				echo "###" >> ${wfile}
 				echo "###Disable auto loading of virtual capes (emmc/video/wireless/adc)" >> ${wfile}
-				echo "#disable_uboot_overlay_emmc=1" >> ${wfile}
+				if [ "x${uboot_disable_emmc}" = "xenable" ] ; then
+					echo "disable_uboot_overlay_emmc=1" >> ${wfile}
+				else
+					echo "#disable_uboot_overlay_emmc=1" >> ${wfile}
+				fi
 				if [ "x${uboot_disable_video}" = "xenable" ] ; then
 					echo "disable_uboot_overlay_video=1" >> ${wfile}
 				else
@@ -2033,6 +2037,9 @@ while [ ! -z "$1" ] ; do
 		;;
 	--enable-uboot-cape-overlays)
 		uboot_cape_overlays="enable"
+		;;
+	--enable-uboot-disable-emmc)
+		uboot_disable_emmc="enable"
 		;;
 	--enable-uboot-disable-video)
 		uboot_disable_video="enable"


### PR DESCRIPTION
The EMMC steals GPIO pins we need. Thus for now we need to disable + run from SD.

I verified this works by flashing the image, starting the beagle, and setting
```
>>> GPIO.setup('P8_4', GPIO.OUT)
>>> GPIO.output('P8_4', 1)
```
which fails if the emmc is active, and setting
```
>>> GPIO.setup('P8_38', GPIO.OUT)
>>> GPIO.output('P8_38', 1)
```
which fails if the LCD is active. Both worked => we're good.